### PR TITLE
Dynamic groups for node roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAMESPACE  := logicmonitor
 REPOSITORY := argus
-VERSION    := 0.2.0-alpha.0
+VERSION    := 0.2.0-alpha.1
 
 all:
 	docker build --build-arg VERSION=$(VERSION) -t $(NAMESPACE)/$(REPOSITORY):latest .

--- a/pkg/argus.go
+++ b/pkg/argus.go
@@ -97,6 +97,8 @@ func NewArgus(base *types.Base, client api.CollectorSetControllerClient) (*Argus
 		},
 		&node.Watcher{
 			DeviceManager: deviceManager,
+			DeviceGroups:  deviceGroups,
+			LMClient:      base.LMClient,
 		},
 		&service.Watcher{
 			DeviceManager: deviceManager,

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -19,6 +19,8 @@ const (
 
 const (
 	// EtcdDeviceGroupName is the service device group name in the cluster device group.
+	// LabelCustomPropertyPrefix is the prefix to use for custom properties based of labels
+	LabelCustomPropertyPrefix = "kubernetes.label."
 	EtcdDeviceGroupName = "Etcd"
 	// NodeDeviceGroupName is the service device group name in the cluster device group.
 	NodeDeviceGroupName = "Nodes"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -18,13 +18,20 @@ const (
 )
 
 const (
-	// EtcdDeviceGroupName is the service device group name in the cluster device group.
+	// LabelNodeRole is the label name used to specify a node's role in the cluster
+	LabelNodeRole = "node-role.kubernetes.io/"
 	// LabelCustomPropertyPrefix is the prefix to use for custom properties based of labels
 	LabelCustomPropertyPrefix = "kubernetes.label."
+)
+
+const (
+	// AllNodeDeviceGroupName is the service device group name in the cluster device group.
+	AllNodeDeviceGroupName = "All"
+	// EtcdDeviceGroupName is the etcd device group name in the cluster device group.
 	EtcdDeviceGroupName = "Etcd"
-	// NodeDeviceGroupName is the service device group name in the cluster device group.
+	// NodeDeviceGroupName is the top-level device group name in the cluster device group.
 	NodeDeviceGroupName = "Nodes"
-	// PodDeviceGroupName is the service device group name in the cluster device group.
+	// PodDeviceGroupName is the pod device group name in the cluster device group.
 	PodDeviceGroupName = "Pods"
 	// ServiceDeviceGroupName is the service device group name in the cluster device group.
 	ServiceDeviceGroupName = "Services"
@@ -51,6 +58,8 @@ const (
 	PodDeletedCategory = "KubernetesPodDeleted"
 	// DeletedDeviceGroup is the name of the device group where deleted devices are optionally moved to.
 	DeletedDeviceGroup = "_deleted"
+	// ClusterDeviceGroupPrefix is the prefix for the top level cluster device group
+	ClusterDeviceGroupPrefix = "Kubernetes Cluster: "
 )
 
 const (

--- a/pkg/device/builder/builder.go
+++ b/pkg/device/builder/builder.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"github.com/logicmonitor/k8s-argus/pkg/constants"
 	"github.com/logicmonitor/k8s-argus/pkg/types"
 	lm "github.com/logicmonitor/lm-sdk-go"
 	log "github.com/sirupsen/logrus"
@@ -32,12 +33,24 @@ func (b *Builder) CollectorID(id int32) types.DeviceOption {
 	}
 }
 
-// SystemCategories implements types.DeviceBuilder.
+// SystemCategories implements types.DeviceBuilder
 func (b *Builder) SystemCategories(categories string) types.DeviceOption {
 	return setProperty("system.categories", categories)
 }
 
-// Auto implements types.DeviceBuilder.
+// ResourceLabels implements types.DeviceBuilder
+func (b *Builder) ResourceLabels(properties map[string]string) types.DeviceOption {
+	return func(device *lm.RestDevice) {
+		for name, value := range properties {
+			device.CustomProperties = append(device.CustomProperties, lm.NameAndValue{
+				Name:  constants.LabelCustomPropertyPrefix + name,
+				Value: value,
+			})
+		}
+	}
+}
+
+// Auto implements types.DeviceBuilder
 func (b *Builder) Auto(name, value string) types.DeviceOption {
 	return setProperty("auto."+name, value)
 }

--- a/pkg/devicegroup/devicegroup.go
+++ b/pkg/devicegroup/devicegroup.go
@@ -128,6 +128,19 @@ func Find(parentID int32, name string, client *lm.DefaultApi) (*lm.RestDeviceGro
 	return deviceGroup, nil
 }
 
+// Exists returns true if the specified device group exists in the account
+func Exists(parentID int32, name string, client *lm.DefaultApi) bool {
+	deviceGroup, err := Find(parentID, name, client)
+	if err != nil {
+		log.Warnf("Failed looking up device group for node role %q: %v", name, err)
+	}
+
+	if deviceGroup != nil {
+		return true
+	}
+	return false
+}
+
 // DeleteSubGroup deletes a subgroup from a device group with the specified
 // name.
 func DeleteSubGroup(deviceGroup *lm.RestDeviceGroup, name string, client *lm.DefaultApi) error {

--- a/pkg/tree/tree.go
+++ b/pkg/tree/tree.go
@@ -78,7 +78,6 @@ func (d *DeviceTree) CreateDeviceTree() (map[string]int32, error) {
 			opts.ParentID = deviceGroups[constants.NodeDeviceGroupName]
 		case constants.ClusterDeviceGroupPrefix + d.Config.ClusterName:
 			// don't do anything for the root cluster group
-			break
 		default:
 			opts.ParentID = deviceGroups[constants.ClusterDeviceGroupPrefix+d.Config.ClusterName]
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -72,6 +72,8 @@ type DeviceBuilder interface {
 	CollectorID(int32) DeviceOption
 	// SystemCategories sets the system.categories property on the device.
 	SystemCategories(string) DeviceOption
+	// ResourceLabels sets custom properties for the device
+	ResourceLabels(map[string]string) DeviceOption
 	// Auto adds an auto property to the device.
 	Auto(string, string) DeviceOption
 	// System adds a system property to the device.

--- a/pkg/utilities/utilities.go
+++ b/pkg/utilities/utilities.go
@@ -22,7 +22,7 @@ func BuildSystemCategoriesFromLabels(categories string, labels map[string]string
 // GetLabelByPrefix takes a list of labels returns the first label matching the specified prefix
 func GetLabelByPrefix(prefix string, labels map[string]string) (string, string) {
 	for k, v := range labels {
-		if match, _ := regexp.MatchString("^"+prefix, k); match == true {
+		if match, _ := regexp.MatchString("^"+prefix, k); match {
 			return k, v
 		}
 	}

--- a/pkg/utilities/utilities.go
+++ b/pkg/utilities/utilities.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"regexp"
 
 	"github.com/logicmonitor/k8s-argus/pkg/metrics"
 
@@ -14,10 +15,18 @@ import (
 func BuildSystemCategoriesFromLabels(categories string, labels map[string]string) string {
 	for k, v := range labels {
 		categories += "," + k + "=" + v
-
 	}
-
 	return categories
+}
+
+// GetLabelByPrefix takes a list of labels returns the first label matching the specified prefix
+func GetLabelByPrefix(prefix string, labels map[string]string) (string, string) {
+	for k, v := range labels {
+		if match, _ := regexp.MatchString("^"+prefix, k); match == true {
+			return k, v
+		}
+	}
+	return "", ""
 }
 
 // CheckAllErrors is a helper function to deal with the number of possible places that an API call can fail.

--- a/pkg/watch/node/node.go
+++ b/pkg/watch/node/node.go
@@ -122,6 +122,7 @@ func (w *Watcher) args(node *v1.Node, category string) []types.DeviceOption {
 	categories := utilities.BuildSystemCategoriesFromLabels(category, node.Labels)
 	return []types.DeviceOption{
 		w.Name(getInternalAddress(node.Status.Addresses).Address),
+		w.ResourceLabels(node.Labels),
 		w.DisplayName(node.Name),
 		w.SystemCategories(categories),
 		w.Auto("name", node.Name),

--- a/pkg/watch/node/node.go
+++ b/pkg/watch/node/node.go
@@ -125,6 +125,7 @@ func (w *Watcher) update(old, new *v1.Node) {
 	}
 }
 
+// nolint: dupl
 func (w *Watcher) move(node *v1.Node) {
 	if _, err := w.UpdateAndReplaceFieldByName(node.Name, constants.CustomPropertiesFieldName, w.args(node, constants.NodeDeletedCategory)...); err != nil {
 		log.Errorf("Failed to move node %q: %v", node.Name, err)

--- a/pkg/watch/pod/pod.go
+++ b/pkg/watch/pod/pod.go
@@ -132,6 +132,7 @@ func (w *Watcher) args(pod *v1.Pod, category string) []types.DeviceOption {
 	categories := utilities.BuildSystemCategoriesFromLabels(category, pod.Labels)
 	return []types.DeviceOption{
 		w.Name(pod.Name),
+		w.ResourceLabels(pod.Labels),
 		w.DisplayName(pod.Name),
 		w.SystemCategories(categories),
 		w.Auto("name", pod.Name),

--- a/pkg/watch/pod/pod.go
+++ b/pkg/watch/pod/pod.go
@@ -120,6 +120,7 @@ func (w *Watcher) update(old, new *v1.Pod) {
 	log.Infof("Updated pod %q", old.Name)
 }
 
+// nolint: dupl
 func (w *Watcher) move(pod *v1.Pod) {
 	if _, err := w.UpdateAndReplaceFieldByName(pod.Name, constants.CustomPropertiesFieldName, w.args(pod, constants.PodDeletedCategory)...); err != nil {
 		log.Errorf("Failed to move pod %q: %v", pod.Name, err)

--- a/pkg/watch/service/service.go
+++ b/pkg/watch/service/service.go
@@ -126,6 +126,7 @@ func (w *Watcher) args(service *v1.Service, category string) []types.DeviceOptio
 	categories := utilities.BuildSystemCategoriesFromLabels(category, service.Labels)
 	return []types.DeviceOption{
 		w.Name(fmtServiceName(service)),
+		w.ResourceLabels(service.Labels),
 		w.DisplayName(fmtServiceDisplayName(service)),
 		w.SystemCategories(categories),
 		w.Auto("name", service.Name),


### PR DESCRIPTION
Create dynamic groups for nodes based on the node-role label. This is nested under Nodes. Adds a catch-all dynamic group "All" which encompasses all cluster nodes, similar to the previous functionality of the "Nodes" group.

Also adds resource labels are custom resources in the format "kubernetes.label.<label name>"


fixes https://github.com/logicmonitor/k8s-argus/issues/79